### PR TITLE
Try to re-calibrate while motors are stopped.

### DIFF
--- a/src/xbot_positioning.cpp
+++ b/src/xbot_positioning.cpp
@@ -208,7 +208,7 @@ void onWheelTicks(const xbot_msgs::WheelTick::ConstPtr &msg) {
         gyro_offset = gyro_offset_s / gyro_offset_samples;
         /* Calculate deviation */
         double deviation = sqrt((gyro_offset_s2-gyro_offset_s*gyro_offset_s/gyro_offset_samples)/(gyro_offset_samples-1));
-        frozen_angular_max_velocity=deviation*5;
+        frozen_angular_max_velocity=fmax(deviation*5,0.05); // Tolerance from deviation (at least one revolution in two minutes)
         /* Reset statistic */
         gyro_offset_s = gyro_offset_s2 = gyro_offset_samples = 0;
 


### PR DESCRIPTION
The gyroscope is calibrated during startup. This calibration is not perfect and gets worse as times goes by for example due to thermal effects.

This pull request tries to re-calibrate every time the mower motors are stopped. As a result the mower no longer performs virtual spinning while paused due to a missing RTK fix or while charging. Heading is no longer lost during this period and navigation may start without the need for a re-orientation based on Kalman filter.